### PR TITLE
fix: accidental modal dismiss

### DIFF
--- a/src/ui/components/Modal.svelte
+++ b/src/ui/components/Modal.svelte
@@ -50,7 +50,7 @@
 
 <dialog
     bind:this={dialog}
-    on:click|capture|nonpassive={backgroundClose}
+    on:mousedown|capture|nonpassive={backgroundClose}
     on:keyup|preventDefault|capture|nonpassive={escapeClose}
     data-theme={$colorScheme}
 >


### PR DESCRIPTION
changing on:click to on:mousedown prevents the modal from being accidentally dismissed if the user overshoots the dialog on text selection with a mouse

closes #10 