### PR TITLE
fix: animation bug

### DIFF
--- a/src/ui/components/Modal.svelte
+++ b/src/ui/components/Modal.svelte
@@ -85,6 +85,7 @@
         );
         padding: var(--space-m);
         background-color: var(--body-background-color);
+        overflow: hidden;
         overflow-y: scroll;
         max-height: var(--max-modal-content-height);
 


### PR DESCRIPTION
fix for #71 by setting `overflow: hidden` to not show a horizontal scrollbar when animating screen transitions