### PR TITLE
add target prop for link component

### DIFF
--- a/src/ui/components/Link.svelte
+++ b/src/ui/components/Link.svelte
@@ -7,12 +7,13 @@
         label: string
         icon?: ComponentProps<Icon>['name']
         variant?: 'primary' | 'secondary' | 'outlined'
+        target?: string
     }
 
-    let {button = true, href, label, icon, variant = 'outlined'} = data
+    let {button = true, href, label, icon, target, variant = 'outlined'} = data
 </script>
 
-<a class:button class={variant} {href} target="_blank" rel="noreferrer">
+<a class:button class={variant} {href} {target} rel="noreferrer">
     {#if icon}
         <Icon name={icon} />
     {/if}


### PR DESCRIPTION
closes #88 by defaulting to `target=""` and developers can choose to add `target="blank"`