### PR TITLE
Fix keyboard navigation

### DIFF
--- a/src/ui/components/Modal.svelte
+++ b/src/ui/components/Modal.svelte
@@ -42,7 +42,7 @@
 
     // When escape keypress is captured, close
     document.addEventListener('keydown', (event) => {
-        if (event.key === 'Escape') {
+        if (event.key === 'Escape' && dialog.open) {
             cancelRequest()
         }
     })

--- a/src/ui/components/Modal.svelte
+++ b/src/ui/components/Modal.svelte
@@ -41,17 +41,16 @@
     }
 
     // When escape keypress is captured, close
-    function escapeClose(event) {
+    document.addEventListener('keydown', (event) => {
         if (event.key === 'Escape') {
             cancelRequest()
         }
-    }
+    })
 </script>
 
 <dialog
     bind:this={dialog}
     on:mousedown|capture|nonpassive|self={backgroundClose}
-    on:keydown|preventDefault={escapeClose}
     data-theme={$settings.theme}
 >
     <Header title={$props.title} subtitle={$props.subtitle} on:cancel={cancelRequest} />


### PR DESCRIPTION
switch to `addEventListener` to maintain default keyboard navigation inside the dialog