### PR TITLE
Add scroll shadows to textarea for interaction affordance

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,5 +1,5 @@
 import type {ChainDefinition, WalletPluginMetadata} from '@wharfkit/session'
-import {settings} from 'src/ui/state'
+import {settings} from '../ui/state'
 import {get} from 'svelte/store'
 import icons, {Icon} from '../ui/components/icons'
 

--- a/src/ui/Prompt.svelte
+++ b/src/ui/Prompt.svelte
@@ -113,8 +113,11 @@
     }>()
 </script>
 
-<div>
-    <Message title={$prompt?.args.title} details={$prompt?.args.body} />
+<div class="prompt">
+    <div class="text">
+        <BodyTitle>{$prompt?.args.title}</BodyTitle>
+        <BodyText>{$prompt?.args.body}</BodyText>
+    </div>
     {#each $elements as component}
         <svelte:component
             this={component.component}
@@ -126,10 +129,17 @@
 </div>
 
 <style>
-    div {
+    .prompt {
         display: flex;
         flex-direction: column;
         gap: var(--space-m);
         gap: var(--space-l);
+    }
+
+    .text {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-s);
+        text-align: center;
     }
 </style>

--- a/src/ui/components/BodyTitle.svelte
+++ b/src/ui/components/BodyTitle.svelte
@@ -7,5 +7,6 @@
         font-weight: 600;
         text-align: center;
         margin: 0;
+        margin-block-start: var(--space-xs);
     }
 </style>

--- a/src/ui/components/ListItem.svelte
+++ b/src/ui/components/ListItem.svelte
@@ -94,6 +94,7 @@
         background: none;
         color: inherit;
         font-size: inherit;
+        font-family: inherit;
         font-weight: inherit;
         margin: 0;
         padding: 0;

--- a/src/ui/components/Textarea.svelte
+++ b/src/ui/components/Textarea.svelte
@@ -1,22 +1,46 @@
 <script lang="ts">
+    import {onMount} from 'svelte'
+
     type TextareaProps = {
         content?: string
     }
 
     export let data: TextareaProps = {}
+
+    let wrapper
+    let textarea
+    let maxOpacity = 0.2
+
+    function handleScroll(event) {
+        let scrollMax = event.target.scrollHeight - event.target.clientHeight
+        let currentScroll = event.target.scrollTop / scrollMax
+        let topShadowOpacity = currentScroll * maxOpacity
+        let bottomShadowOpacity = (1 - currentScroll) * maxOpacity
+        wrapper.style.setProperty('--top-shadow-opacity', topShadowOpacity)
+        wrapper.style.setProperty('--bottom-shadow-opacity', bottomShadowOpacity)
+    }
+
+    onMount(() => {
+        let startingOpacity =
+            (1 - textarea.scrollTop / (textarea.scrollHeight - textarea.clientHeight)) * maxOpacity
+        wrapper.style.setProperty('--bottom-shadow-opacity', startingOpacity)
+    })
 </script>
 
-<div>
-    <textarea readOnly>{data.content}</textarea>
+<div class="wrapper" bind:this={wrapper}>
+    <textarea bind:this={textarea} on:scroll={handleScroll} readOnly>{data.content}</textarea>
 </div>
 
 <style lang="scss">
-    div {
+    .wrapper {
+        position: relative;
         display: flex;
+        display: grid;
         background-color: var(--text-area-background);
-        padding-inline-start: var(--space-m);
-        padding: var(--space-m);
+
+        // padding: var(--space-m);
         border-radius: var(--border-radius-inner);
+        overflow: hidden;
     }
     textarea {
         --rows: 9;
@@ -25,10 +49,35 @@
         background-color: var(--text-area-background);
         border: none;
         font-size: var(--fs-0);
-        font-weight: 600;
+        font-weight: 400;
         line-height: 1.5;
         resize: none;
         opacity: 0.75;
         height: calc(var(--fs-0) * 1.5 * var(--rows) - var(--fs-0) * 1.5 * 0.5);
+        border-radius: inherit;
+        // width: 100%;
+        padding-inline-start: var(--space-m);
+        padding-block-start: var(--space-m);
+    }
+
+    .wrapper::before,
+    .wrapper::after {
+        content: '';
+        display: block;
+        position: absolute;
+        z-index: 2;
+        width: 100%;
+        height: var(--space-l);
+        background: linear-gradient(var(--deg), transparent, black 100%);
+    }
+    .wrapper::before {
+        --deg: 0;
+        top: 0;
+        opacity: var(--top-shadow-opacity, 0);
+    }
+    .wrapper::after {
+        --deg: 180deg;
+        bottom: 0;
+        opacity: var(--bottom-shadow-opacity, 0);
     }
 </style>


### PR DESCRIPTION
adds a shadow at the bottom or top to show there is additional content available when scrolling. Some browsers will hide the scrollbar by default, so this will compensate.