### PR TITLE
Fix error message icon placement

### DIFF
--- a/src/ui/components/Message.svelte
+++ b/src/ui/components/Message.svelte
@@ -23,9 +23,8 @@
 
 <style lang="scss">
     div {
-        display: flex;
-        flex-direction: column;
-        align-items: center;
+        display: grid;
+        justify-items: center;
         gap: var(--space-s);
         text-align: center;
         color: var(--body-text-color);


### PR DESCRIPTION
change flex to grid in message component layout to fix icon placement in webkit browsers 