### PR TITLE
fix: correct screen when publickey exists

### DIFF
--- a/src/lib/translations/en/common.json
+++ b/src/lib/translations/en/common.json
@@ -19,6 +19,7 @@
             "account": "Select an available account",
             "blockchain": "Select which blockchain to login with",
             "wallet": "Connect your wallet to login",
+            "no_accounts": "No accounts found",
             "no_match": "No accounts found matching {{publicKey}}"
         },
         "title": "Login",

--- a/src/ui/components/Modal.svelte
+++ b/src/ui/components/Modal.svelte
@@ -65,8 +65,18 @@
 
     dialog {
         --margin-top: var(--space-xl);
-        font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen,
-            Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+        font-family:
+            system-ui,
+            -apple-system,
+            BlinkMacSystemFont,
+            'Segoe UI',
+            Roboto,
+            Oxygen,
+            Ubuntu,
+            Cantarell,
+            'Open Sans',
+            'Helvetica Neue',
+            sans-serif;
         margin-bottom: 0;
         margin-top: var(--margin-top);
         margin-inline: auto;
@@ -85,6 +95,7 @@
             100svh - var(--header-height) - var(--margin-top) - var(--margin-top)
         );
         padding: var(--space-m);
+        padding-bottom: var(--space-l);
         background-color: var(--body-background-color);
         overflow: hidden;
         overflow-y: scroll;

--- a/src/ui/login/Permission.svelte
+++ b/src/ui/login/Permission.svelte
@@ -38,8 +38,7 @@
     let accountName: Name | undefined
     let accountNotFound: boolean = false
     let permissions: PermissionLevel[] | undefined
-
-    $: publicKey = walletPlugin.metadata.publicKey
+    let publicKey: string | undefined = walletPlugin.metadata.publicKey
 
     onMount(async () => {
         if (walletPlugin.config.requiresPermissionSelect) {
@@ -108,7 +107,7 @@
                 />
             {/each}
         </List>
-    {:else if walletPlugin.metadata.publicKey || walletPlugin.retrievePublicKey}
+    {:else if publicKey}
         <BodyTitle>{$t('login.select.no_accounts')}</BodyTitle>
         <WarningMessage
             title=""

--- a/src/ui/login/Permission.svelte
+++ b/src/ui/login/Permission.svelte
@@ -39,9 +39,10 @@
     let accountNotFound: boolean = false
     let permissions: PermissionLevel[] | undefined
 
+    $: publicKey = walletPlugin.metadata.publicKey
+
     onMount(async () => {
         if (walletPlugin.config.requiresPermissionSelect) {
-            let publicKey = walletPlugin.metadata.publicKey
             if (chainId && walletPlugin.retrievePublicKey) {
                 try {
                     publicKey = String(await walletPlugin.retrievePublicKey(chainId))
@@ -85,7 +86,7 @@
         }
     }
 
-    function handleKeyup(event) {
+    function handleKeyup(event: KeyboardEvent) {
         if (event.code == 'Enter') {
             event.preventDefault()
             lookup()
@@ -107,15 +108,13 @@
                 />
             {/each}
         </List>
-    {:else if walletPlugin.metadata.publicKey}
-        <BodyTitle>{title}</BodyTitle>
+    {:else if walletPlugin.metadata.publicKey || walletPlugin.retrievePublicKey}
+        <BodyTitle>{$t('login.select.no_accounts')}</BodyTitle>
         <WarningMessage
-            title={$t('login.select.no_accounts', {
-                default: 'No accounts found',
-            })}
+            title=""
             details={$t('login.select.no_match', {
                 default: 'No accounts found matching {{publicKey}}',
-                publicKey: walletPlugin.metadata.publicKey,
+                publicKey: publicKey,
             })}
         />
     {:else if !accountName}


### PR DESCRIPTION
Previously, if no publicKey existed in the walletPlugin metadata the conditional would fall through to display the account name entry form. Now if there is a publicKey in metadata OR a retrievePublicKey method the correct "No accounts found" screen will display with the publicKey.

Also, fixed a padding issue in the Modal.