### PR TITLE
optimize language handling for Chinese and plugin translations

### DIFF
--- a/src/lib/translations.ts
+++ b/src/lib/translations.ts
@@ -12,10 +12,19 @@ import tr from './translations/tr/common.json'
 const translations = {
     en: {...lang, ...en},
     ko: {...lang, ...ko},
-    zh: {...lang, ...zh_hans},
     'zh-Hans': {...lang, ...zh_hans},
     'zh-Hant': {...lang, ...zh_hant},
     tr: {...lang, ...tr},
+}
+
+const ZH_LANGUAGE_MAPPINGS: Record<string, string> = {
+    zh: 'zh-Hans',
+    'zh-cn': 'zh-Hans',
+    'zh-sg': 'zh-Hans',
+    'zh-hans': 'zh-Hans',
+    'zh-tw': 'zh-Hant',
+    'zh-hk': 'zh-Hant',
+    'zh-hant': 'zh-Hant',
 }
 
 interface Params {
@@ -41,6 +50,12 @@ export const makeLocalization = (options: UserInterfaceLocalizationOptions = {})
         ...options,
     }
     return new i18n(params)
+}
+
+export function mapChineseLanguage(lang: string): string {
+    if (!lang) return 'zh-Hans'
+    const lowerLang = lang.toLowerCase().trim()
+    return ZH_LANGUAGE_MAPPINGS[lowerLang] || 'zh-Hans'
 }
 
 export const {t, l, locales, locale, loadTranslations, setLocale} = new i18n(config)


### PR DESCRIPTION
1. In the Chinese environment, getNavigatorLanguage() returns zh, which cannot distinguish between zh_hans and zh_hant. WebRenderer#initialize executes loadTranslations('zh').
2. In translations.ts#translations, zh_hans is mapped to zh, but since the plugin is mainly configured with zh_hans, even after addTranslations, it still doesn’t pick up the Chinese translations.